### PR TITLE
7512 - Created image styles for news-main-content and news-attachment…

### DIFF
--- a/config/default/core.entity_view_display.media.image.news_attachment.yml
+++ b/config/default/core.entity_view_display.media.image.news_attachment.yml
@@ -1,0 +1,39 @@
+uuid: a747ed0b-b2c3-4fda-9b4f-dfb0c7f04f1b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.news_attachment
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.news_attachment
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+_core:
+  default_config_hash: 73xaTNkI5J6sfFcBmNYeuk070X3mQS_iwwWaPYyfG2M
+id: media.image.news_attachment
+targetEntityType: media
+bundle: image
+mode: news_attachment
+content:
+  field_media_image:
+    type: responsive_image
+    label: visually_hidden
+    settings:
+      responsive_image_style: news_attachment
+      image_link: content
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/default/core.entity_view_display.media.image.news_main_content.yml
+++ b/config/default/core.entity_view_display.media.image.news_main_content.yml
@@ -1,0 +1,39 @@
+uuid: c99eec34-b45f-4d49-ae3a-84fdd51f4d2b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.news_main_content
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.news_main_content
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+_core:
+  default_config_hash: 73xaTNkI5J6sfFcBmNYeuk070X3mQS_iwwWaPYyfG2M
+id: media.image.news_main_content
+targetEntityType: media
+bundle: image
+mode: news_main_content
+content:
+  field_media_image:
+    type: responsive_image
+    label: visually_hidden
+    settings:
+      responsive_image_style: news_main_content
+      image_link: content
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/default/core.entity_view_display.node.news.attachment.yml
+++ b/config/default/core.entity_view_display.node.news.attachment.yml
@@ -11,11 +11,9 @@ dependencies:
     - field.field.node.news.field_image
     - field.field.node.news.field_image_teaser
     - field.field.node.news.field_paragraphs
-    - image.style.media_library
     - node.type.news
   module:
     - layout_builder
-    - media
     - user
 third_party_settings:
   layout_builder:
@@ -43,13 +41,11 @@ content:
     weight: 2
     region: content
   field_image_teaser:
-    type: media_thumbnail
+    type: entity_reference_entity_view
     label: hidden
     settings:
-      image_link: content
-      image_style: media_library
-      image_loading:
-        attribute: lazy
+      view_mode: news_attachment
+      link: false
     third_party_settings: {  }
     weight: 0
     region: content

--- a/config/default/core.entity_view_display.node.news.main_content.yml
+++ b/config/default/core.entity_view_display.node.news.main_content.yml
@@ -11,11 +11,9 @@ dependencies:
     - field.field.node.news.field_image
     - field.field.node.news.field_image_teaser
     - field.field.node.news.field_paragraphs
-    - image.style.media_library
     - node.type.news
   module:
     - layout_builder
-    - media
     - user
 third_party_settings:
   layout_builder:
@@ -43,13 +41,11 @@ content:
     weight: 2
     region: content
   field_image_teaser:
-    type: media_thumbnail
+    type: entity_reference_entity_view
     label: hidden
     settings:
-      image_link: content
-      image_style: media_library
-      image_loading:
-        attribute: lazy
+      view_mode: news_main_content
+      link: false
     third_party_settings: {  }
     weight: 0
     region: content

--- a/config/default/core.entity_view_mode.media.news_attachment.yml
+++ b/config/default/core.entity_view_mode.media.news_attachment.yml
@@ -1,0 +1,11 @@
+uuid: 197281fd-c771-47e0-b3a9-ebd1fcaa10ee
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.news_attachment
+label: 'News Attachment'
+description: ''
+targetEntityType: media
+cache: true

--- a/config/default/core.entity_view_mode.media.news_main_content.yml
+++ b/config/default/core.entity_view_mode.media.news_main_content.yml
@@ -1,0 +1,11 @@
+uuid: 87e9bf1f-c5d2-4ef0-8796-794c1fa4239a
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.news_main_content
+label: 'News Main Content'
+description: ''
+targetEntityType: media
+cache: true

--- a/config/default/image.style.news_attachment_desktop.yml
+++ b/config/default/image.style.news_attachment_desktop.yml
@@ -1,0 +1,15 @@
+uuid: 95397169-48fe-431b-8482-b3ab02a19d34
+langcode: en
+status: true
+dependencies: {  }
+name: news_attachment_desktop
+label: 'News Attachment| Desktop (268 x 134)'
+effects:
+  fa9359e8-cb0b-4050-8700-f4504ec2f849:
+    uuid: fa9359e8-cb0b-4050-8700-f4504ec2f849
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 268
+      height: 134
+      anchor: center-center

--- a/config/default/image.style.news_main_content_desktop.yml
+++ b/config/default/image.style.news_main_content_desktop.yml
@@ -1,0 +1,15 @@
+uuid: 6e6aea0a-6484-4b46-a121-43b2ff2ef9b6
+langcode: en
+status: true
+dependencies: {  }
+name: news_main_content_desktop
+label: 'News Main Content | Desktop (576 x 386)'
+effects:
+  57a333fa-971e-4155-b01d-044348e0bb41:
+    uuid: 57a333fa-971e-4155-b01d-044348e0bb41
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 576
+      height: 386
+      anchor: center-center

--- a/config/default/image.style.news_preview_without_date_mobile.yml
+++ b/config/default/image.style.news_preview_without_date_mobile.yml
@@ -12,4 +12,4 @@ effects:
     data:
       width: 800
       height: 400
-      upscale: false
+      upscale: true

--- a/config/default/responsive_image.styles.news_attachment.yml
+++ b/config/default/responsive_image.styles.news_attachment.yml
@@ -1,0 +1,25 @@
+uuid: 3675cfc8-7f85-4b24-a551-712c11b93337
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.news_attachment_desktop
+    - image.style.news_preview_without_date_mobile
+    - image.style.wide
+  theme:
+    - kuzya_main
+id: news_attachment
+label: 'News Attachment'
+image_style_mappings:
+  -
+    image_mapping_type: image_style
+    image_mapping: news_attachment_desktop
+    breakpoint_id: kuzya_main.medium
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: news_preview_without_date_mobile
+    breakpoint_id: kuzya_main.small
+    multiplier: 1x
+breakpoint_group: kuzya_main
+fallback_image_style: wide

--- a/config/default/responsive_image.styles.news_main_content.yml
+++ b/config/default/responsive_image.styles.news_main_content.yml
@@ -1,0 +1,24 @@
+uuid: dd9407b3-7766-4dd3-9791-9f41b229e4f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.news_main_content_desktop
+    - image.style.news_preview_without_date_mobile
+  theme:
+    - kuzya_main
+id: news_main_content
+label: 'News Main Content'
+image_style_mappings:
+  -
+    image_mapping_type: image_style
+    image_mapping: news_main_content_desktop
+    breakpoint_id: kuzya_main.medium
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: news_preview_without_date_mobile
+    breakpoint_id: kuzya_main.small
+    multiplier: 1x
+breakpoint_group: kuzya_main
+fallback_image_style: news_main_content_desktop

--- a/config/default/views.view.front_page.yml
+++ b/config/default/views.view.front_page.yml
@@ -1524,7 +1524,7 @@ display:
     display_plugin: block
     position: 2
     display_options:
-      title: 'Main content'
+      title: 'Main Content'
       fields:
         field_image_teaser:
           id: field_image_teaser

--- a/web/themes/custom/kuzya_main/templates/block/block--views-block--front-page-block-main-content.html.twig
+++ b/web/themes/custom/kuzya_main/templates/block/block--views-block--front-page-block-main-content.html.twig
@@ -1,0 +1,6 @@
+<div {{ bem('block', ['frontpage__main-content']) }}>
+
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/web/themes/custom/kuzya_main/templates/content/node--news--attachment.html.twig
+++ b/web/themes/custom/kuzya_main/templates/content/node--news--attachment.html.twig
@@ -1,0 +1,14 @@
+{% set image = content.field_image_teaser.0 %}
+{% set category = content.field_category.0 %}
+{% set description = node.field_description.value %}
+
+{% include "@molecules/card/card-news-preview.twig" with {
+  card__extra_classes: ["card__news--attachment"],
+  card__image: image,
+  card__category: category,
+  card__heading: label,
+  heading_level: 3,
+  card__link__url: url,
+  card__body: description,
+} %}
+

--- a/web/themes/custom/kuzya_main/templates/content/node--news--main-content.html.twig
+++ b/web/themes/custom/kuzya_main/templates/content/node--news--main-content.html.twig
@@ -1,0 +1,25 @@
+{% set image = content.field_image_teaser.0 %}
+{% set category = content.field_category.0 %}
+{% set description = node.field_description.value %}
+
+{% set user_id = node.getOwnerId() %}
+
+{% embed "@molecules/card/card-news-preview.twig" with {
+  card__extra_classes: ["card__news--main-content"],
+  card__image: image,
+  card__category: category,
+  card__heading: label,
+  heading_level: 3,
+  card__link__url: url,
+  card__body: description,
+} %}
+
+  {% block card__author %}
+    {% include "@atoms/links/link/link.twig" with {
+      link_url: '/user/{{ user_id }}',
+      link_content: author_name
+    }%}
+
+  {% endblock %}
+
+{% endembed %}


### PR DESCRIPTION
https://redmine.devbranch.work/issues/7512

Created image styles for news-main-content and news-attachment. 
Created and used image responsive styles. 
The template for node-main-content and node-attachment has been created. 
The template block--views-block--front-page-block-main-content has been overridden. 
Changed a title for view. 
Removed label from block views
