### PR TITLE
7579 - New blocks for Node-news-full have been created. Exposed Filte…

### DIFF
--- a/config/default/core.entity_view_display.media.image.news_full_hero_image.yml
+++ b/config/default/core.entity_view_display.media.image.news_full_hero_image.yml
@@ -1,0 +1,39 @@
+uuid: b9ef4138-9db1-4f9c-9a8c-57a8d002f1b3
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.news_full_hero_image
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.news_full_hero_image
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+_core:
+  default_config_hash: 73xaTNkI5J6sfFcBmNYeuk070X3mQS_iwwWaPYyfG2M
+id: media.image.news_full_hero_image
+targetEntityType: media
+bundle: image
+mode: news_full_hero_image
+content:
+  field_media_image:
+    type: responsive_image
+    label: visually_hidden
+    settings:
+      responsive_image_style: news_full_hero_image
+      image_link: ''
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/default/core.entity_view_display.node.news.category_title.yml
+++ b/config/default/core.entity_view_display.node.news.category_title.yml
@@ -1,0 +1,42 @@
+uuid: 95a11262-c1bc-4312-b582-df5bec5c7afa
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.category_title
+    - field.field.node.news.field_category
+    - field.field.node.news.field_comments
+    - field.field.node.news.field_created
+    - field.field.node.news.field_description
+    - field.field.node.news.field_image
+    - field.field.node.news.field_image_teaser
+    - field.field.node.news.field_paragraphs
+    - node.type.news
+  module:
+    - layout_builder
+    - user
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.news.category_title
+targetEntityType: node
+bundle: news
+mode: category_title
+content:
+  field_category:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_comments: true
+  field_created: true
+  field_description: true
+  field_image: true
+  field_image_teaser: true
+  field_paragraphs: true
+  links: true

--- a/config/default/core.entity_view_display.node.news.default.yml
+++ b/config/default/core.entity_view_display.node.news.default.yml
@@ -76,15 +76,17 @@ third_party_settings:
             region: content
             configuration:
               id: 'field_block:node:news:field_image'
+              label: Image
               label_display: '0'
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
+                view_mode: view_mode
               formatter:
                 type: entity_reference_entity_view
-                label: above
+                label: hidden
                 settings:
-                  view_mode: default
-                  link: false
+                  view_mode: preview
                 third_party_settings: {  }
             weight: 3
             additional: {  }

--- a/config/default/core.entity_view_display.node.news.full.yml
+++ b/config/default/core.entity_view_display.node.news.full.yml
@@ -14,6 +14,7 @@ dependencies:
     - image.style.wide
     - node.type.news
     - views.view.category_page
+    - views.view.front_page
     - views.view.news_full_view_mode
     - views.view.pager
   module:
@@ -33,20 +34,9 @@ third_party_settings:
       -
         layout_id: layout_onecol
         layout_settings:
-          label: 'Hero Block'
+          label: ''
           context_mapping: {  }
         components:
-          71297720-cafd-464a-92b9-b99da56c72f9:
-            uuid: 71297720-cafd-464a-92b9-b99da56c72f9
-            region: content
-            configuration:
-              id: menu_social_media_black_bar
-              label: 'Menu Social Media Black Bar'
-              label_display: visible
-              provider: kenny_core
-              context_mapping: {  }
-            weight: 9
-            additional: {  }
           1b5f61e3-7107-452c-a50c-737a1c952ec1:
             uuid: 1b5f61e3-7107-452c-a50c-737a1c952ec1
             region: content
@@ -59,94 +49,35 @@ third_party_settings:
                 entity: layout_builder.entity
                 view_mode: view_mode
               formatter:
-                type: media_thumbnail
+                type: entity_reference_entity_view
                 label: hidden
                 settings:
-                  image_link: ''
-                  image_style: wide
-                  image_loading:
-                    attribute: lazy
+                  view_mode: news_full_hero_image
                 third_party_settings: {  }
-            weight: 1
+            weight: 0
             additional: {  }
-          1a5dba11-1a86-4682-80b1-b769e1548233:
-            uuid: 1a5dba11-1a86-4682-80b1-b769e1548233
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: 'Section Hero Block'
+          context_mapping: {  }
+        components:
+          6a656f7d-7c05-4cbe-bb6c-1fe69ffebcef:
+            uuid: 6a656f7d-7c05-4cbe-bb6c-1fe69ffebcef
             region: content
             configuration:
-              id: 'field_block:node:news:field_category'
-              label: Category
-              label_display: '0'
-              provider: layout_builder
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
-              formatter:
-                type: entity_reference_label
-                label: hidden
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 2
+              id: 'views_block:front_page-block_hero_news_full'
+              label: ''
+              label_display: visible
+              provider: views
+              context_mapping: {  }
+              views_label: ''
+              items_per_page: none
+            weight: 0
             additional: {  }
-          fa86add9-937e-4d70-8a3a-7a4d01529bc3:
-            uuid: fa86add9-937e-4d70-8a3a-7a4d01529bc3
-            region: content
-            configuration:
-              id: 'field_block:node:news:title'
-              label: Title
-              label_display: '0'
-              provider: layout_builder
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
-              formatter:
-                type: string
-                label: hidden
-                settings:
-                  link_to_entity: false
-                third_party_settings: {  }
-            weight: 3
-            additional: {  }
-          8e4259a4-671c-4d2a-8d08-2d4b30846228:
-            uuid: 8e4259a4-671c-4d2a-8d08-2d4b30846228
-            region: content
-            configuration:
-              id: 'field_block:node:news:field_category'
-              label: Category
-              label_display: '0'
-              provider: layout_builder
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
-              formatter:
-                type: entity_reference_label
-                label: hidden
-                settings:
-                  link: true
-                third_party_settings: {  }
-            weight: 4
-            additional: {  }
-          7bbbb0bf-1d07-42de-ae47-caa30bdef74f:
-            uuid: 7bbbb0bf-1d07-42de-ae47-caa30bdef74f
-            region: content
-            configuration:
-              id: 'field_block:node:news:title'
-              label: Title
-              label_display: '0'
-              provider: layout_builder
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
-              formatter:
-                type: string
-                label: hidden
-                settings:
-                  link_to_entity: false
-                third_party_settings: {  }
-            weight: 5
-            additional: {  }
-          39d361b5-0aad-4de5-b4a4-c15ba416ee7c:
-            uuid: 39d361b5-0aad-4de5-b4a4-c15ba416ee7c
+          b0a8894f-2011-4158-aa33-e637c68d3451:
+            uuid: b0a8894f-2011-4158-aa33-e637c68d3451
             region: content
             configuration:
               id: 'views_block:news_full_view_mode-block_short_info_about_author'
@@ -156,7 +87,25 @@ third_party_settings:
               context_mapping: {  }
               views_label: ''
               items_per_page: none
-            weight: 8
+            weight: 1
+            additional: {  }
+        third_party_settings: {  }
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: 'Social bar'
+          context_mapping: {  }
+        components:
+          71297720-cafd-464a-92b9-b99da56c72f9:
+            uuid: 71297720-cafd-464a-92b9-b99da56c72f9
+            region: content
+            configuration:
+              id: menu_social_media_black_bar
+              label: 'Menu Social Media Black Bar'
+              label_display: visible
+              provider: kenny_core
+              context_mapping: {  }
+            weight: 0
             additional: {  }
         third_party_settings: {  }
       -

--- a/config/default/core.entity_view_mode.media.news_full_hero_image.yml
+++ b/config/default/core.entity_view_mode.media.news_full_hero_image.yml
@@ -1,0 +1,11 @@
+uuid: 1b389bfb-38e9-4cbf-81e3-30a46d70b419
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.news_full_hero_image
+label: 'News Full Hero Image'
+description: ''
+targetEntityType: media
+cache: true

--- a/config/default/core.entity_view_mode.node.category_title.yml
+++ b/config/default/core.entity_view_mode.node.category_title.yml
@@ -1,0 +1,11 @@
+uuid: bd9e09c7-dd30-4aa1-b30f-3b1f49a53cbc
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.category_title
+label: 'Category Title'
+description: ''
+targetEntityType: node
+cache: true

--- a/config/default/image.style.news_full_desktop.yml
+++ b/config/default/image.style.news_full_desktop.yml
@@ -1,0 +1,15 @@
+uuid: e8389c5b-7556-445a-9949-4e50e68e5a46
+langcode: en
+status: true
+dependencies: {  }
+name: news_full_desktop
+label: 'News Full | Desktop (height 700)'
+effects:
+  e5dc39d8-35b3-4f33-a8e8-f1f20b5a7c2a:
+    uuid: e5dc39d8-35b3-4f33-a8e8-f1f20b5a7c2a
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1141
+      height: 700
+      anchor: center-center

--- a/config/default/image.style.news_full_medium.yml
+++ b/config/default/image.style.news_full_medium.yml
@@ -1,0 +1,15 @@
+uuid: 21697b04-a0e1-4792-8f83-6267cbe3a3e1
+langcode: en
+status: true
+dependencies: {  }
+name: news_full_medium
+label: 'News Full | Medium (height 500)'
+effects:
+  761b605b-a3a6-422b-914c-93b22056dcc1:
+    uuid: 761b605b-a3a6-422b-914c-93b22056dcc1
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1139
+      height: 500
+      anchor: center-center

--- a/config/default/image.style.news_full_mobile.yml
+++ b/config/default/image.style.news_full_mobile.yml
@@ -1,0 +1,15 @@
+uuid: 29627b99-11fc-44fc-98d1-51b10c6b1d6f
+langcode: en
+status: true
+dependencies: {  }
+name: news_full_mobile
+label: 'News Full | Mobile (height 500)'
+effects:
+  9a8cee00-5824-454c-83ce-850c49a22e09:
+    uuid: 9a8cee00-5824-454c-83ce-850c49a22e09
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 789
+      height: 500
+      anchor: center-center

--- a/config/default/image.style.user_image_icon.yml
+++ b/config/default/image.style.user_image_icon.yml
@@ -1,0 +1,15 @@
+uuid: c5ffa49e-b807-4e3d-8a8a-a86d9247e3e8
+langcode: en
+status: true
+dependencies: {  }
+name: user_image_icon
+label: 'User Image Icon | 26x26'
+effects:
+  50cb1533-e483-46f3-ad1d-5f73faafd1e4:
+    uuid: 50cb1533-e483-46f3-ad1d-5f73faafd1e4
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 30
+      height: 30
+      anchor: center-center

--- a/config/default/responsive_image.styles.news_full_hero_image.yml
+++ b/config/default/responsive_image.styles.news_full_hero_image.yml
@@ -1,0 +1,31 @@
+uuid: d9606901-305a-4fd5-8203-18f46a710ded
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.news_full_desktop
+    - image.style.news_full_medium
+    - image.style.news_full_mobile
+    - image.style.wide
+  theme:
+    - kuzya_main
+id: news_full_hero_image
+label: 'News Full Hero Image'
+image_style_mappings:
+  -
+    image_mapping_type: image_style
+    image_mapping: news_full_medium
+    breakpoint_id: kuzya_main.medium
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: news_full_desktop
+    breakpoint_id: kuzya_main.extra-large
+    multiplier: 1x
+  -
+    image_mapping_type: image_style
+    image_mapping: news_full_mobile
+    breakpoint_id: kuzya_main.small
+    multiplier: 1x
+breakpoint_group: kuzya_main
+fallback_image_style: wide

--- a/config/default/views.view.categories.yml
+++ b/config/default/views.view.categories.yml
@@ -311,7 +311,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '<a href="/newspaper_life_news/category/entertainment?category={{ tid }}" id="edit-category-{{ tid }}" name="category[{{ tid }}]" class="bef-link">{{ name }} </a>'
+            text: '<a href="/taxonomy/term/{{ tid }}" id="edit-category-{{ tid }}" name="category[{{ tid }}]" class="bef-link">{{ name }} </a>'
             make_link: false
             path: 'newspaper_life_news/category/entertainment?category=6'
             absolute: false

--- a/config/default/views.view.category_page.yml
+++ b/config/default/views.view.category_page.yml
@@ -12,18 +12,6 @@ dependencies:
     - field.storage.node.field_image_teaser
     - image.style.media_library
     - node.type.news
-    - taxonomy.vocabulary.category
-  content:
-    - 'taxonomy_term:category:202ea89f-5498-49f0-8b3c-50ca9535626b'
-    - 'taxonomy_term:category:2b709781-7bf4-416b-8ea0-1584a94440eb'
-    - 'taxonomy_term:category:409d044f-5ea4-4a3c-8501-30c475e73ed7'
-    - 'taxonomy_term:category:4abcf1d2-837d-4f2e-bee3-54c4f494a284'
-    - 'taxonomy_term:category:4ea9a18f-46c7-44e9-9f48-d51a123b1cc1'
-    - 'taxonomy_term:category:8268dcdb-5e0d-40b0-96f8-433e589fac54'
-    - 'taxonomy_term:category:83b2f655-d4e5-4ea2-8a0b-c768fe9fb21f'
-    - 'taxonomy_term:category:b38bd04a-d11a-4346-8139-24846a3b03de'
-    - 'taxonomy_term:category:e3c0e14c-7029-40cd-b99e-a73ec4314077'
-    - 'taxonomy_term:category:f373ebc2-ab74-4d7b-8988-a0bc6b54f557'
   module:
     - better_exposed_filters
     - datetime
@@ -919,16 +907,20 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: numeric
-          default_action: ignore
+          default_action: default
           exception:
             value: all
             title_enable: false
             title: All
           title_enable: false
           title: ''
-          default_argument_type: fixed
+          default_argument_type: taxonomy_tid
           default_argument_options:
-            argument: ''
+            term_page: '1'
+            node: false
+            limit: false
+            vids: {  }
+            anyall: ','
           summary_options:
             base_path: ''
             count: true
@@ -999,64 +991,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        field_category_target_id:
-          id: field_category_target_id
-          table: node__field_category
-          field: field_category_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: taxonomy_index_tid
-          operator: or
-          value:
-            3: 3
-            8: 8
-            12: 12
-            9: 9
-            11: 11
-            10: 10
-            6: 6
-            4: 4
-            7: 7
-            5: 5
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_category_target_id_op
-            label: Category
-            description: ''
-            use_operator: false
-            operator: field_category_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: category
-            required: false
-            remember: true
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              content_editor: '0'
-              administrator: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          vid: category
-          type: select
-          hierarchy: true
-          limit: true
-          error_message: true
       filter_groups:
         operator: AND
         groups:

--- a/config/default/views.view.front_page.yml
+++ b/config/default/views.view.front_page.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.attachment
+    - core.entity_view_mode.node.category_title
     - core.entity_view_mode.node.fashion_with_image
     - core.entity_view_mode.node.frontpage_sidebar_small
     - core.entity_view_mode.node.info
@@ -1498,6 +1499,670 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
+  block_hero_breadcrumb:
+    id: block_hero_breadcrumb
+    display_title: 'Hero Breadcrumbs Block'
+    display_plugin: block
+    position: 13
+    display_options:
+      title: 'Hero Breadcrumb'
+      fields:
+        field_category:
+          id: field_category
+          table: node__field_category
+          field: field_category
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        title: false
+        pager: false
+        style: false
+        row: false
+        relationships: false
+        fields: false
+        arguments: false
+        header: false
+      relationships:
+        field_category:
+          id: field_category
+          table: node__field_category
+          field: field_category
+          relationship: none
+          group_type: group
+          admin_label: 'field_category: Taxonomy term'
+          plugin_id: standard
+          required: false
+      display_description: ''
+      header: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_category'
+  block_hero_news_full:
+    id: block_hero_news_full
+    display_title: 'Hero News Full Block'
+    display_plugin: block
+    position: 13
+    display_options:
+      title: 'Hero Title Block'
+      fields:
+        field_category:
+          id: field_category
+          table: node__field_category
+          field: field_category
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: category_title
+      defaults:
+        title: false
+        pager: false
+        style: false
+        row: false
+        relationships: false
+        fields: false
+        arguments: false
+        header: false
+      relationships:
+        field_category:
+          id: field_category
+          table: node__field_category
+          field: field_category
+          relationship: none
+          group_type: group
+          admin_label: 'field_category: Taxonomy term'
+          plugin_id: standard
+          required: false
+      display_description: ''
+      header: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_category'
+  block_hero_title:
+    id: block_hero_title
+    display_title: 'Hero Title Block'
+    display_plugin: block
+    position: 13
+    display_options:
+      title: 'Hero Title Block'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_category:
+          id: field_category
+          table: node__field_category
+          field: field_category
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        title: false
+        pager: false
+        style: false
+        row: false
+        relationships: false
+        fields: false
+        arguments: false
+        header: false
+      relationships:
+        field_category:
+          id: field_category
+          table: node__field_category
+          field: field_category
+          relationship: none
+          group_type: group
+          admin_label: 'field_category: Taxonomy term'
+          plugin_id: standard
+          required: false
+      display_description: ''
+      header: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_category'
   block_latest_news_frontpage:
     id: block_latest_news_frontpage
     display_title: 'Block Latest News FrontPage'

--- a/config/default/views.view.news_full_view_mode.yml
+++ b/config/default/views.view.news_full_view_mode.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.storage.user.field_description
     - field.storage.user.user_picture
     - image.style.media_library
+    - image.style.user_image_icon
     - node.type.news
   module:
     - datetime
@@ -544,7 +545,7 @@ display:
           type: image
           settings:
             image_link: ''
-            image_style: media_library
+            image_style: user_image_icon
             image_loading:
               attribute: lazy
           group_column: ''

--- a/web/themes/custom/kuzya_main/components/03-organisms/site/site-news-full/_site-news-full.scss
+++ b/web/themes/custom/kuzya_main/components/03-organisms/site/site-news-full/_site-news-full.scss
@@ -1,0 +1,338 @@
+.node--full {
+
+  &__container {
+
+    .layout--onecol > .layout__region {
+      position: relative;
+    }
+
+
+
+    .field--image {
+      position: absolute;
+      z-index: 1;
+      bottom: unset;
+      margin-top: -50px;
+
+      @include desc {
+        margin-bottom: -30px;
+      }
+
+      @include descMedium {
+        margin-bottom: -50px;
+      }
+
+      @include descLarge {
+        margin-top: -4em;
+      }
+
+      picture::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.3);
+      }
+
+      img {
+        height: 500px;
+        object-fit: cover;
+        width: 100vw;
+
+        @include descLarge {
+          height: 700px;
+        }
+
+      }
+    }
+
+    .block--hero-container {
+      position: relative;
+      padding-top: 250px;
+      max-width: 90%;
+      margin: 0 auto;
+      height: 350px;
+
+      @include descMedium {
+        max-width: 80%;
+      }
+
+      @include descLarge {
+        padding-top: 400px;
+        height: 500px;
+      }
+
+      .block--hero-breadcrumb {
+        display: flex;
+        z-index: 5;
+        position: relative;
+        justify-content: center;
+        align-items: center;
+        margin-bottom: 10px;
+
+        .category {
+          display: inline-flex;
+          align-items: center;
+          margin-right: 5px;
+
+          a {
+            font-size: 12px;
+            line-height: 1.2;
+            font-family: $font-paragraph;
+            color: $header-primary;
+            text-decoration: none;
+            flex-grow: 0.5;
+
+            @include desc {
+              font-size: 11px;
+            }
+
+            @include descLarge {
+              font-size: 12px;
+            }
+
+            &:hover {
+              color: $secondary;
+            }
+          }
+        }
+
+        .title {
+          display: inline-flex;
+          align-items: center;
+          margin-right: 5px;
+
+          span {
+            display: flex;
+            align-items: center;
+            font-size: 12px;
+            line-height: 1.2;
+            font-family: $font-paragraph;
+            color: $header-primary;
+            flex-grow: 0.5;
+
+            @include desc {
+              font-size: 11px;
+            }
+
+            @include descLarge {
+              font-size: 12px;
+            }
+
+            &::before {
+              content: ' - ';
+              display: block;
+              position: relative;
+              margin-right: 5px;
+              color: $desc;
+            }
+          }
+        }
+
+      }
+
+      .block--hero-main-info {
+        display: flex;
+        z-index: 5;
+        position: relative;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+
+        .category {
+
+          a {
+            font-size: 11px;
+            font-family: $font-main;
+            color: $header-primary;
+            text-decoration: none;
+
+            display: inline-block;
+            width: max-content;
+            z-index: 5;
+            margin: 0 5px 5px 0;
+            padding: 5px 6px 3px;
+            border-width: 1px;
+            border-style: solid;
+            border-color: $color-secondary-desc;
+            line-height: 1;
+            font-weight: 400;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+
+            @include descLarge {
+              font-size: 12px;
+            }
+
+            &:hover {
+              border-color: $header-primary;
+            }
+          }
+        }
+
+        .title {
+          margin-top: 10px;
+
+          span {
+            font-size: 26px;
+            color: $header-primary;
+            line-height: 1.2;
+            font-weight: 600;
+            display: inline-block;
+            position: relative;
+            text-align: center;
+
+            @include desc {
+              font-size: 32px;
+            }
+
+            @include descLarge {
+              font-size: 40px;
+            }
+          }
+        }
+      }
+    }
+
+    .block--hero-news-full__about-author {
+      display: flex;
+      justify-content: center;
+      width: max-content;
+      position: relative;
+      align-items: center;
+      margin: 10px auto 0 auto;
+      z-index: 5;
+      height: 100px;
+
+      .views-row {
+        display: flex;
+        flex-direction: row;
+        color: $header-primary;
+
+        .views-field-user-picture {
+
+          margin-right: 6px;
+
+          img {
+            width: 26px;
+            height: 26px;
+            border-radius: 50%;
+          }
+        }
+
+        .views-field-name {
+
+          a {
+            display: inline-flex;
+            color: $header-primary;
+            font-family: $font-main;
+            font-size: 12px;
+            line-height: 30px;
+            font-weight: 400;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            text-decoration: none;
+
+            @include desc {
+              font-size: 11px;
+            }
+
+            @include descLarge {
+              font-size: 12px;
+            }
+
+            &::before {
+              content: ' By ';
+              display: block;
+              position: relative;
+              margin-right: 5px;
+              color: $header-primary;
+              font-weight: 300;
+              line-height: 30px;
+              font-size: 12px;
+            }
+
+            &:hover {
+              color: $secondary;
+            }
+          }
+        }
+
+        .views-field-field-created {
+
+          display: inline-flex;
+
+          .field-content {
+            display: inherit;
+          }
+
+          time {
+            color: $header-primary;
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            font-size: 12px;
+            line-height: 30px;
+            font-weight: 300;
+            letter-spacing: 1px;
+
+            @include desc {
+              font-size: 11px;
+            }
+
+            @include descLarge {
+              font-size: 12px;
+            }
+
+            &::before {
+              content: ' - ';
+              display: block;
+              position: relative;
+              margin: 0 5px;
+              color: $header-primary;
+            }
+          }
+        }
+
+        .views-field-counter {
+
+          .field-content {
+            display: inline-flex;
+            color: $header-primary;
+            font-family: $font-main;
+            font-size: 12px;
+            line-height: 30px;
+            font-weight: 400;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+          }
+
+        }
+
+        .views-field-comment-count {
+
+          .field-content {
+            display: inline-flex;
+            color: $header-primary;
+            font-family: $font-main;
+            font-size: 12px;
+            line-height: 30px;
+            font-weight: 400;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+          }
+        }
+
+        .views-field-counter {
+          .field-content {
+            display: flex;
+            position: relative;
+            margin: 0 15px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/web/themes/custom/kuzya_main/kuzya_main.breakpoints.yml
+++ b/web/themes/custom/kuzya_main/kuzya_main.breakpoints.yml
@@ -4,9 +4,9 @@ kuzya_main.small:
 kuzya_main.small-med:
   label: small-med
   mediaQuery: 'all and (min-width: 26em)'
-kuzya_main.small-large:
-  label: small-large
-  mediaQuery: 'all and (min-width: 41em)'
+kuzya_main.extra-large:
+  label: Desktop-large
+  mediaQuery: 'all and (min-width: 1140px)'
 kuzya_main.medium:
   label: Medium
   mediaQuery: 'all and (min-width: 790px)'

--- a/web/themes/custom/kuzya_main/templates/block/news-full/block--views-block--front-page-block-hero-news-full.html.twig
+++ b/web/themes/custom/kuzya_main/templates/block/news-full/block--views-block--front-page-block-hero-news-full.html.twig
@@ -1,0 +1,34 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+
+<div {{ bem('block', ['hero-news-full']) }}>
+
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/web/themes/custom/kuzya_main/templates/block/news-full/block--views-block--news-full-view-mode-block-short-info-about-author.html.twig
+++ b/web/themes/custom/kuzya_main/templates/block/news-full/block--views-block--news-full-view-mode-block-short-info-about-author.html.twig
@@ -1,0 +1,34 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+
+<div {{ bem('block', ['hero-news-full__about-author']) }}>
+
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/web/themes/custom/kuzya_main/templates/content/node--news--category-title.html.twig
+++ b/web/themes/custom/kuzya_main/templates/content/node--news--category-title.html.twig
@@ -1,0 +1,29 @@
+{% set category = content.field_category.0 %}
+
+<div {{ bem('block', ['hero-container']) }}>
+
+  <div {{ bem('block', ['hero-breadcrumb']) }}>
+
+    <div {{ bem('category') }}>
+      {{ category }}
+    </div>
+
+    <div {{ bem('title') }}>
+      {{ label }}
+    </div>
+
+  </div>
+
+  <div {{ bem('block', ['hero-main-info']) }}>
+
+    <div {{ bem('category') }}>
+      {{ category }}
+    </div>
+
+    <div {{ bem('title') }}>
+      {{ label }}
+    </div>
+
+  </div>
+
+</div>

--- a/web/themes/custom/kuzya_main/templates/content/node--news--full.html.twig
+++ b/web/themes/custom/kuzya_main/templates/content/node--news--full.html.twig
@@ -1,0 +1,111 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{#  @todo 'Old code' #}
+{#{% set count = 1 %}#}
+
+<article {{ bem("node--full") }}>
+
+  <div{{ bem('node--full__container')}}>
+{#    @todo 'Old code. Maybe used in the future '#}
+{#    {% for layout in content._layout_builder %}#}
+{#       <div {{ bem('region', [loop.index])}}>#}
+{#         {% if layout.content %}#}
+{#           {% for item in layout.content %}#}
+{#             <div {{ bem('row', [count])}} >#}
+{#               {{ item.content }}#}
+{#             </div>#}
+{#             {% set count = count + 1 %}#}
+{#           {% endfor %}#}
+{#         {% endif %}#}
+
+{#         {% if layout.first %}#}
+{#           <div class="column-first">#}
+{#             {{ layout.first }}#}
+{#           </div>#}
+{#         {% endif %}#}
+
+{#         {% if layout.second %}#}
+{#           <div class="column-second">#}
+{#             {{ layout.second }}#}
+{#           </div>#}
+{#         {% endif %}#}
+
+{#       </div>#}
+{#    {% endfor %}#}
+    {{ content }}
+  </div>
+
+</article>
+
+
+

--- a/web/themes/custom/kuzya_main/templates/fields/field--node--field-image--news--full.html.twig
+++ b/web/themes/custom/kuzya_main/templates/fields/field--node--field-image--news--full.html.twig
@@ -1,0 +1,6 @@
+<div {{ bem('field', ['image']) }}>
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+</div>
+


### PR DESCRIPTION
https://redmine.devbranch.work/issues/7579
New blocks for Node-news-full have been created. 
Exposed Filter changed to simple links. 
Hero Block has been stylized. 
Overridden template for blocks.
During the task, I caught a stupor, completely abandoned preprocess, and returned to blocks through view to at least somehow complete this task and move on to the next ones. And only then, without further ado, return to this task and do it properly